### PR TITLE
feat: annotate package-level failures, e.g. `goleak`

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -19831,7 +19831,7 @@ var createAnnotations = (suiteSummary, reruns) => {
         (r) => r.packageName === packageName && r.testName === testName
       );
       const testAnnotation = getAnnotationFromOutput(
-        `${packageName}.${testName}`,
+        testName ? `${packageName}.${testName}` : packageName,
         packagePath,
         testSummary,
         rerun
@@ -19928,14 +19928,14 @@ var addEventToSummary = (summary, event) => {
     Output: output,
     Action: action
   } = event ?? {};
-  if (!packageName || !testName) {
+  if (!packageName) {
     return summary;
   }
   const packageSummary = summary.get(packageName) ?? createPackageSummary();
   const testSummary = packageSummary.get(testName) ?? createTestSummary();
   summary.set(packageName, packageSummary);
   packageSummary.set(testName, testSummary);
-  if (action === "run") {
+  if (action === "run" || action === "start") {
     testSummary.output.push("");
   }
   if (output) {

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -24,7 +24,7 @@ const createAnnotations = (
       );
 
       const testAnnotation = getAnnotationFromOutput(
-        `${packageName}.${testName}`,
+        testName ? `${packageName}.${testName}` : packageName,
         packagePath,
         testSummary,
         rerun

--- a/src/suite-summary.ts
+++ b/src/suite-summary.ts
@@ -4,7 +4,7 @@ import type { TestEvent } from './test-report.js';
 type SuiteSummary = Map<string, PackageSummary>;
 
 /** A map of all tests in a package by the test name. */
-type PackageSummary = Map<string, TestSummary>;
+type PackageSummary = Map<string | undefined, TestSummary>;
 
 /** The summary of an individual test or parent test. */
 interface TestSummary {
@@ -44,7 +44,7 @@ const addEventToSummary = (
     Action: action,
   } = event ?? {};
 
-  if (!packageName || !testName) {
+  if (!packageName) {
     return summary;
   }
 
@@ -54,7 +54,7 @@ const addEventToSummary = (
   summary.set(packageName, packageSummary);
   packageSummary.set(testName, testSummary);
 
-  if (action === 'run') {
+  if (action === 'run' || action === 'start') {
     testSummary.output.push('');
   }
 

--- a/tests/annotations.spec.ts
+++ b/tests/annotations.spec.ts
@@ -32,6 +32,25 @@ describe('createAnnotations', () => {
     ]);
   });
 
+  it('gets annotation for a package failure', () => {
+    const summary: SuiteSummary = new Map([
+      [
+        'github.com/owner/repo/greet',
+        new Map([[undefined, { status: 'fail', output: ['oh no!'] }]]),
+      ],
+    ]);
+
+    const result = Subject.createAnnotations(summary, []);
+
+    expect(result).toEqual([
+      {
+        title: 'FAIL: github.com/owner/repo/greet',
+        message: 'oh no!',
+        level: 'error',
+      },
+    ]);
+  });
+
   it('extracts a test file from a test output', () => {
     const summary: SuiteSummary = new Map([
       [

--- a/tests/suite-summary.spec.ts
+++ b/tests/suite-summary.spec.ts
@@ -96,4 +96,28 @@ describe('createSuiteSummary', () => {
       ])
     );
   });
+
+  it('collects package-level failures and output', async () => {
+    const result = await Subject.createSuiteSummary(
+      stream.Readable.from([
+        { Package: 'greet', Action: 'start' },
+        { Package: 'greet', Action: 'output', Output: 'hello' },
+        { Package: 'greet', Action: 'fail' },
+        { Package: 'greet', Action: 'start' },
+        { Package: 'greet', Action: 'output', Output: 'world' },
+        { Package: 'greet', Action: 'pass' },
+      ])
+    );
+
+    expect(result).toEqual(
+      new Map([
+        [
+          'greet',
+          new Map([
+            [undefined, { status: 'fail', output: ['hello', 'world'] }],
+          ]),
+        ],
+      ])
+    );
+  });
 });


### PR DESCRIPTION
## Overview

Some go test results are not attached to a `Test`, but instead are attached solely to the `Package`. One example of this is our results from `goleak`.

This PR updates the annotator to collect and log output and failures at the `Package` level

## Review requests

Since we're getting frequent goleak failures at the moment, I will pull this commit into one of our CI workflows to smoke test / demo the package-level annotations 